### PR TITLE
adding standaradization on city field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 downloads
 ground-control-kyc-checks
 .env
+kyc-checks

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+SHELL=/usr/bin/env bash
+
+build:
+	go build -o kyc-checks ./cmd
+
+run:
+	go run ./cmd run
+
+clean:
+	go clean
+	rm -f kyc-checks
+
+fmt:
+	go fmt ./...
+	gofumpt -w .
+
+lint:
+	golangci-lint run
+
+test:
+	go test -p 4 -v ./...
+
+.PHONY: build run clean test

--- a/checks/geoip/check_geo.go
+++ b/checks/geoip/check_geo.go
@@ -45,8 +45,7 @@ func LoadGeoData() (*GeoData, error) {
 	}, nil
 }
 
-func (g *GeoData) filterByMinerID(ctx context.Context, minerID string,
-	currentEpoch int64) (*GeoData, error) {
+func (g *GeoData) filterByMinerID(ctx context.Context, minerID string, currentEpoch int64) (*GeoData, error) {
 	minEpoch := currentEpoch - 14*24*60*2 // 2 weeks
 	multiaddrsIPs := []MultiaddrsIPsRecord{}
 	ipsGeoLite2 := make(map[string]IPsGeolite2Record)
@@ -85,6 +84,7 @@ func (g *GeoData) filterByMinerID(ctx context.Context, minerID string,
 type ExtraArtifacts struct {
 	GeoData           *GeoData
 	GeocodeLocations  []geodist.Coord
+	GeoDataAddresses  []Address
 	GoogleGeocodeData []maps.GeocodingResult
 }
 
@@ -283,12 +283,13 @@ func GeoMatchExists(ctx context.Context, geodata *GeoData,
 		return false, extraArtifacts, nil
 	}
 
-	locations, googleResponse, err := geocodeAddress(ctx, geocodeClient,
+	locations, addresses, googleResponse, err := geocodeAddress(ctx, geocodeClient,
 		fmt.Sprintf("%s, %s", city, countryCode))
 	if err != nil {
 		log.Fatalf("Geocode error: %s", err)
 	}
 	extraArtifacts.GeocodeLocations = locations
+	extraArtifacts.GeoDataAddresses = addresses
 	extraArtifacts.GoogleGeocodeData = googleResponse
 
 	match_found := false

--- a/checks/geoip/check_geo_test.go
+++ b/checks/geoip/check_geo_test.go
@@ -82,7 +82,7 @@ func TestGeoMatchExists(t *testing.T) {
 				},
 			)
 		}
-		if os.Getenv("GOOGLE_MAPS_API_KEY") == "skip" {
+		if false {
 			log.Println("Warning: Skipping tests as GOOGLE_MAP_API_KEY set to 'skip'")
 		} else {
 			cases = append(

--- a/checks/geoip/check_geo_test.go
+++ b/checks/geoip/check_geo_test.go
@@ -82,7 +82,7 @@ func TestGeoMatchExists(t *testing.T) {
 				},
 			)
 		}
-		if false {
+		if os.Getenv("GOOGLE_MAPS_API_KEY") == "skip" {
 			log.Println("Warning: Skipping tests as GOOGLE_MAP_API_KEY set to 'skip'")
 		} else {
 			cases = append(

--- a/checks/geoip/google_geocode.go
+++ b/checks/geoip/google_geocode.go
@@ -2,6 +2,7 @@ package geoip
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 
@@ -21,10 +22,61 @@ func getGeocodeClient() (*maps.Client, error) {
 	return maps.NewClient(maps.WithAPIKey(key))
 }
 
-func geocodeAddress(ctx context.Context, client *maps.Client,
-	address string) ([]geodist.Coord, []maps.GeocodingResult, error) {
+type Address struct {
+	StreetNumber string `json:"street_number"`
+	Route        string `json:"route"`
+	City         string `json:"city"`
+	State        string `json:"state"`
+	CityState    string `json:"city_state"`
+	Country      string `json:"country"`
+}
+
+func getAddressComponents(components []maps.AddressComponent) Address {
+	var address Address
+
+	for _, c := range components {
+		if contains(c.Types, "street_number") {
+			address.StreetNumber = c.LongName
+		} else if contains(c.Types, "route") {
+			address.Route = c.LongName
+		} else if contains(c.Types, "locality") {
+			if address.Country == "United States" {
+				address.CityState = fmt.Sprintf("%s, %s", c.LongName, address.State)
+				if address.State != "" {
+					address.CityState = fmt.Sprintf("%s, %s", address.CityState, address.State)
+				}
+			} else {
+				address.City = c.LongName
+			}
+		} else if contains(c.Types, "administrative_area_level_1") {
+			if address.Country == "United States" {
+				address.State = fmt.Sprintf("%s, %s", c.ShortName, address.State)
+				if address.City != "" {
+					address.CityState = fmt.Sprintf("%s, %s", address.City, address.State)
+				}
+			} else {
+				address.State = c.LongName
+			}
+		} else if contains(c.Types, "country") {
+			address.Country = c.ShortName
+		}
+	}
+
+	return address
+}
+
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func geocodeAddress(ctx context.Context, client *maps.Client, address string) ([]geodist.Coord, []Address, []maps.GeocodingResult, error) {
 	if client == nil {
-		return []geodist.Coord{}, []maps.GeocodingResult{}, nil
+		return []geodist.Coord{}, []Address{}, []maps.GeocodingResult{}, nil
 	}
 
 	r := &maps.GeocodingRequest{
@@ -32,17 +84,22 @@ func geocodeAddress(ctx context.Context, client *maps.Client,
 	}
 	resp, err := client.Geocode(ctx, r)
 	if err != nil {
-		return []geodist.Coord{}, resp, err
+		return []geodist.Coord{}, []Address{}, resp, err
 	}
 
 	var locations []geodist.Coord
+	var addresses []Address
 	for _, r := range resp {
 		location := geodist.Coord{
 			Lat: r.Geometry.Location.Lat,
 			Lon: r.Geometry.Location.Lng,
 		}
 		locations = append(locations, location)
+
+		addr := getAddressComponents(r.AddressComponents)
+		addresses = append(addresses, addr)
 	}
 
-	return locations, resp, nil
+	// TODO add address response
+	return locations, addresses, resp, nil
 }


### PR DESCRIPTION
# Description

when our google form takes in the city results, these are user defined fields without any validation. This causes issues with the results and they need to be normalized, exmaples are:

```
denver vs denver co
Gwangju vs Gwangju, Jeolla Province
Las Vegas vs Las Vegas NV
Meishan vs MeiShan China
```

# Solution

use google apis `AddressCompnent` to normalize the city -- for example, in the US we want a normalized `City State` format, in other areas we just want a normalized `City`.

https://pkg.go.dev/googlemaps.github.io/maps#AddressComponent